### PR TITLE
Simplify config save

### DIFF
--- a/intf/slowsub_looper_intf.lua
+++ b/intf/slowsub_looper_intf.lua
@@ -308,7 +308,6 @@ function default_config()
     data.general = {}
     data.general.rate = 1
     data.status = {}
-    data.status.first_run = true
     data.status.restarted = true
     return data
 end

--- a/slowsub.lua
+++ b/slowsub.lua
@@ -152,16 +152,15 @@ function on_click_save()
     --Verify the checkbox and set the config file
     if not cb_extraintf:get_checked() then
         vlc.config.set("extraintf", "")
+        vlc.config.set("lua-intf", "")
         cfg.status.first_run = true
         cfg.general.rate = "1"
         save_config(cfg)
         vlc.deactivate()
         return
-    else
-        --if user uncheck the box at next start the looper doesn't work
-        vlc.config.set("extraintf", "luaintf")
-        cfg.general.rate = dd_rate:get_text()
     end
+    
+    cfg.general.rate = dd_rate:get_text()
     save_config(cfg)
     dlg:hide()
 end

--- a/slowsub.lua
+++ b/slowsub.lua
@@ -51,7 +51,7 @@ function activate()
         create_dialog_restart()
         return
     end
-    if cfg.status.first_run then
+    if vlc.config.get("lua-intf") ~= "slowsub_looper_intf" then
         create_dialog_enable_extension()
         return
     end
@@ -150,7 +150,6 @@ end
 function enable_extension()
     vlc.config.set("extraintf", "luaintf")
     vlc.config.set("lua-intf", "slowsub_looper_intf")
-    cfg.status.first_run = false
     cfg.status.restarted = false
     save_config(cfg)
     dlg:hide()
@@ -170,7 +169,6 @@ function on_click_save()
     --Verify the checkbox and set the config file
     if not cb_extraintf:get_checked() then
         vlc.config.set("lua-intf", "")
-        cfg.status.first_run = true
         cfg.general.rate = "1"
         save_config(cfg)
         vlc.deactivate()
@@ -249,7 +247,6 @@ function default_config()
     data.general = {}
     data.general.rate = 1
     data.status = {}
-    data.status.first_run = true
     data.status.restarted = true
     return data
 end

--- a/slowsub.lua
+++ b/slowsub.lua
@@ -47,7 +47,8 @@ end
 
 function activate()
     cfg = load_config()
-    if not cfg.status.restarted then
+    -- The second check is required to manage crashes of VLC
+    if not cfg.status.restarted and vlc.config.get("lua-intf") == "slowsub_looper_intf" then
         create_dialog_restart()
         return
     end


### PR DESCRIPTION
Remove unuseful operations when saving settings.

`extraintf` needs to be set only once during the enable procedure, not every time we save the settings.

Disabling `extraintf` may have side effects on other LUA interfaces?? Not sure.